### PR TITLE
Fixed exception at round end

### DIFF
--- a/game.py
+++ b/game.py
@@ -230,9 +230,9 @@ class hangman_game():
         else:
             #Wrong guess
             self.wrong_guess(current_char)
+        self.clear_entry()
         self.check_victory()
         self.check_gameover()
-        self.clear_entry()
 
     def init_elements(self):
         self.hang_label = GUI.Label(textvariable=self.gamedata.hang_textvar)


### PR DESCRIPTION
After a game finishes (both lose or win), it will throw an exception:
```
Exception in Tkinter callback
Traceback (most recent call last):
  File "C:\Program Files\Python39\lib\tkinter\__init__.py", line 1892, in __call__
    return self.func(*args)
  File "C:\Users\root\Documents\GitHub\Hangman\game.py", line 235, in guess_character
    self.clear_entry()
  File "C:\Users\root\Documents\GitHub\Hangman\game.py", line 183, in clear_entry
    self.text_entry.delete(0, "end")
  File "C:\Program Files\Python39\lib\tkinter\__init__.py", line 3039, in delete
    self.tk.call(self._w, 'delete', first, last)
_tkinter.TclError: invalid command name ".!entry"
```

This can be fixed just by reordering `clear_entry()` to run before `check_victory()` and `check_gameover()`